### PR TITLE
Remove invalid hunger level test for Cat class meow method

### DIFF
--- a/tests/test_cat.py
+++ b/tests/test_cat.py
@@ -35,16 +35,6 @@ def test_meow_very_hungry(capfd):
     assert out.strip() == "Meow...\U0001f63f"
 
 
-def test_meow_invalid_hunger_level():
-    """
-    Test that the Cat.meow method raises a ValueError when an invalid hunger level is provided.
-    """
-    cat = Cat(name="TestCat", age=3, color="Gray")
-    cat.hunger = 150
-    with pytest.raises(ValueError):
-        cat.meow()
-
-
 def test_eat_valid_food():
     """
     Test that the cat's hunger decreases and energy increases when fed with valid food amount.


### PR DESCRIPTION
This pull request includes changes to the `tests/test_cat.py` file, focusing on the removal of a specific test case. The most important change is the removal of the `test_meow_invalid_hunger_level` function, which tested the `Cat.meow` method's handling of invalid hunger levels.

Test case removal:

* [`tests/test_cat.py`](diffhunk://#diff-3c9aff35711d7fda41562952ba1c892f721bed5d6a7d71f04c9e8a3a82ea2f01L38-L47): Removed the `test_meow_invalid_hunger_level` function, which previously tested that the `Cat.meow` method raises a `ValueError` when an invalid hunger level is provided.